### PR TITLE
fix: make default make target work in this environment

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -1,5 +1,10 @@
 FROM archlinux:base-20260111.0.480139
 
+# On Arch Linux /bin is a symlink to usr/bin. Docker cannot bind-mount a file
+# into a path that resolves through a symlinked directory, which breaks cqfd's
+# entrypoint injection. Convert /bin into a real directory.
+RUN cp -a /usr/bin/. /tmp/bin.real/ && rm /bin && mv /tmp/bin.real /bin
+
 RUN pacman -Syu --noconfirm \
     cloc \
     curl \
@@ -7,6 +12,7 @@ RUN pacman -Syu --noconfirm \
     jq \
     make \
     neovim \
+    sudo \
     which
 
 COPY plenary-patches /plenary-patches

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 .PHONY: cqfd
 cqfd:
 	@git submodule update --init > /dev/null
-	@./scripts/cqfd/cqfd init > /dev/null
-	@./scripts/cqfd/cqfd run make tests
+	@mkdir -p /var/lib/openclaw/cqfd-tmp
+	@TMPDIR=/var/lib/openclaw/cqfd-tmp USER=openclaw ./scripts/cqfd/cqfd init > /dev/null
+	@TMPDIR=/var/lib/openclaw/cqfd-tmp USER=openclaw ./scripts/cqfd/cqfd run make test
 
 .PHONY: test tests
 test tests:


### PR DESCRIPTION
The default `make` target (cqfd → docker) had several issues preventing it from running in this jail environment:

1. **Arch Linux `/bin` symlink**: `/bin` in Arch is a symlink to `/usr/bin`. Docker cannot bind-mount a file into a path that resolves through a symlinked directory, breaking cqfd's entrypoint injection. Fixed by converting `/bin` to a real directory in the Dockerfile.

2. **Missing `sudo`**: cqfd prefers `sudo` over `su` for privilege dropping. The Arch `su` uses `--session-command` which passes commands to bash as `bash --`, which fails on the container's bash version. Added `sudo` to the Dockerfile.

3. **Hardcoded `/tmp` in cqfd**: The jail's `/tmp` is a tmpfs; Docker cannot bind-mount files from tmpfs into containers. Patched cqfd to respect `$TMPDIR` and set it to a persistent path in the Makefile.

4. **`$USER` unset in jail**: cqfd uses `$USER` for container username; falls back to `'builder'` (with literal quotes) when unset. Set `USER=openclaw` explicitly in the Makefile.