### PR TITLE
dockerfile: add sudo

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN pacman -Syu --noconfirm \
     jq \
     make \
     neovim \
+    sudo \
     which
 
 COPY plenary-patches /plenary-patches


### PR DESCRIPTION
cqfd prefers `sudo` over `su` for dropping privileges when running commands as the build user. Without it, cqfd falls back to `su --session-command` which passes the command to bash as `bash --`, causing a failure on Arch Linux's bash.