### PR TITLE
cqfdrc: mount git dir to support use as a submodule

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -6,6 +6,7 @@ name='ai_nvim'
 command=""
 docker_run_args=" \
     -v $HOME/.config/github-copilot/apps.json:$HOME/.config/github-copilot/apps.json \
+    -v $(git rev-parse --git-dir):$(git rev-parse --git-dir) \
 "
 
 # vi: ft=ini


### PR DESCRIPTION
When ai.nvim is used as a git submodule, `.git` is a file pointing to the parent repo's git directory rather than a directory itself. This causes git commands to fail inside the cqfd container since the git dir isn't mounted.

Mounts `$(git rev-parse --git-dir)` into the container so git works correctly whether the plugin is a standalone repo or a submodule.