### PR TITLE
test: add online_it() helper to skip online tests with OFFLINE_ONLY=1

### DIFF
--- a/tests/ai_spec.lua
+++ b/tests/ai_spec.lua
@@ -179,6 +179,14 @@ local function ai_describe(name, fn)
     end)
 end
 
+local function online_it(name, fn)
+    if vim.env.OFFLINE_ONLY == '1' then
+        pending(name)
+    else
+        it(name, fn)
+    end
+end
+
 ai_describe(":Ai", function()
 
     it("does not error", function()
@@ -958,7 +966,7 @@ ai_describe("g:ai_responses", function()
 
     describe("for copilot endpoint", function()
 
-        it("/copilot_internal/v2/token returns valid json online", function()
+        online_it("/copilot_internal/v2/token returns valid json online", function()
 
             vim.g.i_am_in_a_test = false
 
@@ -996,7 +1004,7 @@ ai_describe("g:ai_responses", function()
             assert(is_valid_token_json(token))
         end)
 
-        it("/models returns valid json online", function()
+        online_it("/models returns valid json online", function()
 
             vim.g.i_am_in_a_test = false
 


### PR DESCRIPTION
Tests that make real network requests set `vim.g.i_am_in_a_test = false` to disable mocking. These are now wrapped with `online_it()` instead of `it()`.

When `OFFLINE_ONLY=1` is set, `online_it()` marks the test as `pending` rather than running it — no credentials needed.

```sh
OFFLINE_ONLY=1 make test   # skips online tests
make test                  # runs everything (needs apps.json)
```

This is the foundation for safe CI on untrusted PRs: run with `OFFLINE_ONLY=1`, no Copilot token required.