### PR TITLE
docs: document OFFLINE_ONLY=1 for running tests without credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ To run the tests without cqfd:
 make test
 ```
 
+To run only the offline tests (no Copilot credentials required):
+
+```sh
+OFFLINE_ONLY=1 make test
+```
+
 ## CLOC
 
 This plugin was made out of spite against the growing trend of all lua-based


### PR DESCRIPTION
Documents the `OFFLINE_ONLY=1` env var introduced alongside `online_it()` for skipping tests that require real Copilot API access.