### PR TITLE
fix: pre-existing test failures

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -16,3 +16,7 @@ RUN mkdir -p /usr/local/share/nvim/site/pack/plenary/start && \
     cd /usr/local/share/nvim/site/pack/plenary/start && \
     git clone --depth 1 https://github.com/nvim-lua/plenary.nvim.git && \
     git -C plenary.nvim apply /plenary-patches/*.patch
+
+RUN mkdir -p /root/.config/github-copilot && \
+    echo '{"github.com":{"oauth_token":"ghu_fakefakefakefakefakefake000000000000"}}' \
+    > /root/.config/github-copilot/apps.json

--- a/autoload/ai.vim
+++ b/autoload/ai.vim
@@ -392,7 +392,10 @@ function! ai#enqueue_job(job) abort
 endf
 
 function! ai#wait_for_jobs() abort
-    while g:ai_job_running
+    while g:ai_job_running || len(g:ai_job_queue) > 0
+        if !g:ai_job_running
+            call ai#run_job_queue()
+        endi
         sleep 10m
     endw
 endf

--- a/autoload/providers/copilot.vim
+++ b/autoload/providers/copilot.vim
@@ -76,9 +76,10 @@ endf
 
 function! s:build_token_curl_cmd() abort
     let url = "https://api.github.com/copilot_internal/v2/token"
+    let token = providers#copilot#get_local_token()
 
     let headers = [
-        \   $"authorization: Bearer {providers#copilot#get_local_token()}",
+        \   $"authorization: Bearer {token}",
         \   $"accept: application/json",
         \]
 

--- a/tests/ai_spec.lua
+++ b/tests/ai_spec.lua
@@ -154,12 +154,13 @@ local function teardown()
     for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
         vim.api.nvim_buf_delete(bufnr, { force = true })
     end
+    vim.cmd("silent! %bwipeout!")
     vim.cmd("silent! only")
 
     vim.g.i_am_in_a_test = true
 
-    vim.system({ "git", "clean", "-fq", vim.g.ai_dir, default_mock_dir }):wait()
-    vim.system({ "git", "restore", vim.g.ai_dir, default_mock_dir }):wait()
+    vim.fn.system({ "git", "clean", "-fdq", vim.g.ai_dir, default_mock_dir })
+    vim.fn.system({ "git", "restore", vim.g.ai_dir, default_mock_dir })
     vim.g.ai_dir = default_mock_dir
 
     vim.g.ai_test_endpoints = nil
@@ -170,6 +171,8 @@ local function teardown()
     vim.g.ai_model_params = vim.empty_dict()
 
     vim.fn['ai#wait_for_jobs']()
+    vim.g.ai_job_queue = {}
+    vim.g.ai_job_running = false
 end
 
 local function ai_describe(name, fn)


### PR DESCRIPTION
Fixes multiple pre-existing failures that prevented the test suite from running cleanly.

**`test: add fake apps.json to docker image for tests`**
The test container had `apps.json` mounted as a directory, causing `E484: Can't open file` in `get_local_token()`. Adds a fake `apps.json` to the Docker image so all token-related tests can run without real credentials.

**`fix: extract token var to avoid E696 in list literal`**
`$"authorization: Bearer {providers#copilot#get_local_token()}"` in a list literal caused `E696: Missing comma in List` due to vimscript's parser misreading the `}`. Extracted to a local variable first.

**`fix: wait_for_jobs waits until queue is empty`**
`ai#wait_for_jobs` only waited while `g:ai_job_running` was true. When a job's `on_exit` handler re-enqueued more jobs (e.g. token-expiry retry), the new jobs could run after `wait_for_jobs` returned — writing to the chat during teardown or the next test.

**`test: improve teardown isolation between test cases`**
- `%bwipeout!` wipes stale in-memory buffers
- `vim.fn.system` (synchronous) instead of `vim.system`
- `git clean -fdq` to also remove untracked directories
- Reset `ai_job_queue` and `ai_job_running` after waiting