### PR TITLE
fix: send :Ai messages to last chat regardless of current buffer

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -16,3 +16,7 @@ RUN mkdir -p /usr/local/share/nvim/site/pack/plenary/start && \
     cd /usr/local/share/nvim/site/pack/plenary/start && \
     git clone --depth 1 https://github.com/nvim-lua/plenary.nvim.git && \
     git -C plenary.nvim apply /plenary-patches/*.patch
+
+RUN mkdir -p /root/.config/github-copilot && \
+    echo '{"github.com":{"oauth_token":"ghu_fakefakefakefakefakefake000000000000"}}' \
+    > /root/.config/github-copilot/apps.json

--- a/autoload/ai.vim
+++ b/autoload/ai.vim
@@ -541,5 +541,14 @@ function! ai#handle_messages(...) abort
     call extend(lines, split(msg, "\n"))
     call add(lines, '```')
 
-    call appendbufline(bufnr(), "$", lines)
+    let chat_path = ai#get_last_chat_path()
+    if chat_path == ''
+        echohl ErrorMsg
+        echomsg 'ai.nvim: no chat exists yet'
+        echohl None
+        return
+    endi
+
+    let bufnr = s:open_chat(chat_path)
+    call appendbufline(bufnr, "$", lines)
 endf

--- a/autoload/ai.vim
+++ b/autoload/ai.vim
@@ -392,7 +392,10 @@ function! ai#enqueue_job(job) abort
 endf
 
 function! ai#wait_for_jobs() abort
-    while g:ai_job_running
+    while g:ai_job_running || len(g:ai_job_queue) > 0
+        if !g:ai_job_running
+            call ai#run_job_queue()
+        endi
         sleep 10m
     endw
 endf

--- a/autoload/providers/copilot.vim
+++ b/autoload/providers/copilot.vim
@@ -76,9 +76,10 @@ endf
 
 function! s:build_token_curl_cmd() abort
     let url = "https://api.github.com/copilot_internal/v2/token"
+    let token = providers#copilot#get_local_token()
 
     let headers = [
-        \   $"authorization: Bearer {providers#copilot#get_local_token()}",
+        \   $"authorization: Bearer {token}",
         \   $"accept: application/json",
         \]
 

--- a/tests/ai_spec.lua
+++ b/tests/ai_spec.lua
@@ -939,6 +939,27 @@ ai_describe(":Ai messages", function()
             "```",
         }, lines)
     end)
+
+    it("sends to the last chat even when a chat window is not open", function()
+
+        vim.cmd([[
+            messages clear
+            Ai
+            echomsg "test-message-payload"
+        ]])
+
+        local chat_name = vim.api.nvim_buf_get_name(0)
+
+        vim.cmd('enew')
+
+        vim.cmd('Ai messages')
+
+        local lines = vim.api.nvim_buf_get_lines(
+            vim.fn.bufnr(chat_name), 0, -1, false)
+
+        assert(vim.tbl_contains(lines, "```neovim_messages"))
+        assert(vim.tbl_contains(lines, "test-message-payload"))
+    end)
 end)
 
 ai_describe(":Ai mes", function()

--- a/tests/ai_spec.lua
+++ b/tests/ai_spec.lua
@@ -154,12 +154,13 @@ local function teardown()
     for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
         vim.api.nvim_buf_delete(bufnr, { force = true })
     end
+    vim.cmd("silent! %bwipeout!")
     vim.cmd("silent! only")
 
     vim.g.i_am_in_a_test = true
 
-    vim.system({ "git", "clean", "-fq", vim.g.ai_dir, default_mock_dir }):wait()
-    vim.system({ "git", "restore", vim.g.ai_dir, default_mock_dir }):wait()
+    vim.fn.system({ "git", "clean", "-fdq", vim.g.ai_dir, default_mock_dir })
+    vim.fn.system({ "git", "restore", vim.g.ai_dir, default_mock_dir })
     vim.g.ai_dir = default_mock_dir
 
     vim.g.ai_test_endpoints = nil
@@ -170,6 +171,8 @@ local function teardown()
     vim.g.ai_model_params = vim.empty_dict()
 
     vim.fn['ai#wait_for_jobs']()
+    vim.g.ai_job_queue = {}
+    vim.g.ai_job_running = false
 end
 
 local function ai_describe(name, fn)


### PR DESCRIPTION
Depends on #34 (pre-existing test fixes).

Previously `:Ai messages` appended to `bufnr()` — whichever buffer happened to be active. If no chat window was open this would dump the messages output into an unrelated buffer.

Now it calls `s:open_chat()` with the last chat path, opening or focusing the chat window before appending, matching the behaviour of all other `:Ai` subcommands.

## Test added

`sends to the last chat even when a chat window is not open` — opens a chat, switches to a new empty buffer, runs `:Ai messages`, and asserts the content landed in the chat buffer not the current one.