### PR TITLE
fix: send :Ai messages to last chat regardless of current buffer

### DIFF
--- a/autoload/ai.vim
+++ b/autoload/ai.vim
@@ -538,5 +538,14 @@ function! ai#handle_messages(...) abort
     call extend(lines, split(msg, "\n"))
     call add(lines, '```')
 
-    call appendbufline(bufnr(), "$", lines)
+    let chat_path = ai#get_last_chat_path()
+    if chat_path == ''
+        echohl ErrorMsg
+        echomsg 'ai.nvim: no chat exists yet'
+        echohl None
+        return
+    endi
+
+    let bufnr = s:open_chat(chat_path)
+    call appendbufline(bufnr, "$", lines)
 endf

--- a/tests/ai_spec.lua
+++ b/tests/ai_spec.lua
@@ -936,6 +936,27 @@ ai_describe(":Ai messages", function()
             "```",
         }, lines)
     end)
+
+    it("sends to the last chat even when a chat window is not open", function()
+
+        vim.cmd([[
+            messages clear
+            Ai
+            echomsg "test-message-payload"
+        ]])
+
+        local chat_name = vim.api.nvim_buf_get_name(0)
+
+        vim.cmd('enew')
+
+        vim.cmd('Ai messages')
+
+        local lines = vim.api.nvim_buf_get_lines(
+            vim.fn.bufnr(chat_name), 0, -1, false)
+
+        assert(vim.tbl_contains(lines, "```neovim_messages"))
+        assert(vim.tbl_contains(lines, "test-message-payload"))
+    end)
 end)
 
 ai_describe(":Ai mes", function()


### PR DESCRIPTION
Previously `:Ai messages` appended to `bufnr()` — whichever buffer happened to be active. If no chat window was open this would dump the messages output into an unrelated buffer.

Now it calls `s:open_chat()` with the last chat path, opening or focusing the chat window before appending, matching the behaviour of all other `:Ai` subcommands.

## Test added

`sends to the last chat even when a chat window is not open` — opens a chat, switches to a new empty buffer, runs `:Ai messages`, and asserts the content landed in the chat buffer not the current one.